### PR TITLE
Adding permission to get SSM parameters for the CodeBuild role

### DIFF
--- a/code/aft-deployment-pipeline.yaml
+++ b/code/aft-deployment-pipeline.yaml
@@ -606,6 +606,16 @@ Resources:
                 Condition:
                   StringEqualsIfExists:
                     events:creatorAccount: "${aws:PrincipalAccount}"
+        - PolicyName: SSMParameterPermissions
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:GetParametersByPath
+                Resource: !Sub "arn:${AWS::Partition}:ssm:*:*:parameter/*"
     Metadata:
       cfn_nag:
         rules_to_suppress:


### PR DESCRIPTION
# Description

### Motivation and Context

AFT 1.12.1 introduces new data resources which implies more permissions for the pipeline role
- Resolves #1 

### How was this change tested?

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)

### Additional Notes

Generic permissions have been added to the CodeBuild IAM role to allow the pipeline to get SSM parameter information in the pipeline account.